### PR TITLE
Updated to work with Projectile again

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package is inspired by [multi-term.el](https://github.com/milkypostman/mult
 | multi-vterm-next             | Switch to next terminal                         |
 | multi-vterm-prev             | Switch to previous terminal                     |
 | multi-vterm-dedicated-toggle | Toggle dedicated terminal                       |
-| multi-vterm-projectile       | Create/toggle terminal based on current project |
+| multi-vterm-project          | Create/toggle terminal based on current project |
 
 # For Evil users
 

--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -58,6 +58,9 @@ If nil, this defaults to the SHELL environment variable."
 (defconst multi-vterm-dedicated-buffer-name "dedicated"
   "The dedicated vterm buffer name.")
 
+(defconst multi-vterm-projectile-installed-p (require 'projectile nil 'noerror)
+  "Indicate installation of projectile.")
+
 ;; Variables
 (defvar multi-vterm-dedicated-window nil
   "The dedicated `multi-vterm' window.")
@@ -83,7 +86,9 @@ If nil, this defaults to the SHELL environment variable."
 (defun multi-vterm-project ()
   "Create new vterm buffer."
   (interactive)
-  (if (project-current)
+  (if (if multi-vterm-projectile-installed-p
+          (projectile-project-p)
+        (project-current))
       (if (buffer-live-p (get-buffer (multi-vterm-project-get-buffer-name)))
           (if (string-equal (buffer-name (current-buffer)) (multi-vterm-project-get-buffer-name))
               (delete-window (selected-window))
@@ -150,8 +155,10 @@ Optional argument DEDICATED-WINDOW: There are three types of DEDICATED-WINDOW: d
             ((eq dedicated-window 'project) (progn
                                               (setq vterm-name (multi-vterm-project-get-buffer-name))
                                               (setq default-directory
-                                                    (project-root
-                                                     (or (project-current) `(transient . ,default-directory))))))
+                                                    (if multi-vterm-projectile-installed-p
+                                                        (projectile-project-root)
+                                                      (project-root
+                                                       (or (project-current) `(transient . ,default-directory)))))))
             (t (progn
                  (while (buffer-live-p (get-buffer (multi-vterm-format-buffer-index index)))
                    (setq index (1+ index)))
@@ -167,7 +174,9 @@ Optional argument DEDICATED-WINDOW: There are three types of DEDICATED-WINDOW: d
 (defun multi-vterm-project-get-buffer-name ()
   "Get project buffer name."
   (multi-vterm-format-buffer-name
-   (project-root (or (project-current) `(transient . ,default-directory)))))
+   (if multi-vterm-projectile-installed-p
+       (projectile-project-root)
+     (project-root (or (project-current) `(transient . ,default-directory))))))
 
 (defun multi-vterm-rename-buffer (name)
   "Rename vterm buffer to NAME."


### PR DESCRIPTION
Hi there,

I have been struggling to get this package working with Projectile for a little while assuming that my Projectile configuration had something stupid I'd done, so I was putting off debugging it for quite a while. However after some deeper investigation I discovered that Projectile was actually removed from this package last year which would explain my issue. 

After the Projectile dependency was removed, I'm not sure if it was due to a change in projectile's handling of things or not, but this stopped working with my installation. Any time project.el functions are executed they return `nil' because projectile is being used instead.

Primary change here is to create a new const which evaluates whether or not Projectile is available to use, if so it loads it. Then it just checks if this const is true (technically the value is 'projectile') when doing anything that requires project.el functionality and instead uses the projectile version of said command instead.

I basically followed along with PR #13 to undo what was done to remove Projectile and add a quick check instead. I'm a relatively new elisp-er so I'm not sure if there's a better way of constructing this admittedly personal fix but I figured I'd open a PR to see what you thought. Feel free to decline this (or to provide some suggestions for improvement as well!) and I'll happily make due on my end.

Cheers!