### PR TITLE
add dedicated termial height in percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ This package is inspired by [multi-term.el](https://github.com/milkypostman/mult
 (use-package multi-vterm :ensure t)
 ```
 
+# Configuration
+
+## Dedicated terminal height
+Configure the height in rows:
+```elisp
+;; dedicated terminal height of 50 rows
+(setq multi-vterm-dedicated-window-height 50)
+```
+Configure the height in percent:
+```elisp
+;; dedicated terminal height of 30%
+(setq multi-vterm-dedicated-window-height-percent 30)
+```
+If `multi-vterm-dedicated-window-height-percent` is set `multi-vterm-dedicated-window-height` is ignored.
+**Note**: The lower limit is 10% and the upper limit is 90%.
+
 # Usage
 
 | Command                         | Description                                     |

--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -54,9 +54,17 @@ If nil, this defaults to the SHELL environment variable."
   :type 'integer
   :group 'multi-vterm)
 
+(defcustom multi-vterm-dedicated-window-height-percent nil
+  "The height of the `multi-vterm' dedicated window in percent of rows."
+  :type 'integer
+  :group 'multi-vterm)
+
 ;; Contants
 (defconst multi-vterm-dedicated-buffer-name "dedicated"
   "The dedicated vterm buffer name.")
+
+(defconst multi-vterm-dedicated-window-height-percent-limits '(10 90)
+  "The dedicated vterm buffer height boundaries in percent")
 
 ;; Variables
 (defvar multi-vterm-dedicated-window nil
@@ -238,9 +246,9 @@ Option OFFSET for skip OFFSET number term buffer."
 (defun multi-vterm-dedicated-get-window ()
   "Get `multi-vterm' dedicated window."
   (setq multi-vterm-dedicated-window
-        (split-window
-         (selected-window)
-         (- (multi-vterm-current-window-height) multi-vterm-dedicated-window-height))))
+	(split-window
+	 (selected-window)
+	 (- (multi-vterm-current-window-height) (multi-vterm-dedicated-calc-window-height)))))
 
 (defun multi-vterm-current-window-height (&optional window)
   "Return the height the `window' takes up.
@@ -249,6 +257,17 @@ If `window' is nil, get current window."
   (let ((edges (window-edges window)))
     (- (nth 3 edges) (nth 1 edges))))
 
+(defun multi-vterm-dedicated-calc-window-height ()
+  "Return the height the dedicated `multi-vterm' window should have"
+  (if multi-vterm-dedicated-window-height-percent
+      (let* ((percent (min multi-vterm-dedicated-window-height-percent
+			      (nth 1 multi-vterm-dedicated-window-height-percent-limits)))
+	     (percent (max percent
+			      (nth 0 multi-vterm-dedicated-window-height-percent-limits))))
+	(ceiling (* (float (multi-vterm-current-window-height))
+		    (/ (float percent)
+		       100))))
+	multi-vterm-dedicated-window-height))
 
 (defun multi-vterm-dedicated-get-buffer-name ()
   "Get the buffer name of `multi-vterm' dedicated window."


### PR DESCRIPTION
Let's you specify the dedicated terminal height in percent instead of a fix number of rows. Useful if you deal with different monitor sizes.